### PR TITLE
fix: if two build buttons, move second to basics

### DIFF
--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -977,7 +977,7 @@ void Gui::computeDisplay(){
 					if(u->isBuilt()){
 						//printf("u->isBuilt()\n");
 
-						int morphPos= CommandHelper::getMorphPos();
+						int morphPos= CommandHelper::getRowPos(crMorphs);
 						for(int i= 0; i < ut->getCommandTypeSortedCount(); ++i){
 							int displayPos= i;
 							const CommandType *ct= ut->getCommandTypeSorted(i);
@@ -1030,7 +1030,7 @@ void Gui::computeDisplay(){
 				else{
 					//printf("selection.isUniform() == FALSE\n");
 					//non uniform selection
-					int basicPos=  CommandHelper::getBasicPos();
+					int basicPos=  CommandHelper::getRowPos(crBasics);
 					// only basics can be shared
 					for(auto &&cc : CommandHelper::getBasicsCC()){
 

--- a/source/glest_game/types/command_type.cpp
+++ b/source/glest_game/types/command_type.cpp
@@ -36,14 +36,11 @@ namespace Glest{ namespace Game{
 // =====================================================	
 
 int CommandHelper::getBasicPos(CommandClass cc){
-	switch(cc) {
-	case ccAttack: return 0; break;
-	case ccStop: return 1; break;
-	case ccMove: return 2; break;
-	case ccAttackStopped: return 3; break;
-	default:
-		return ccNull;
-	}
+	auto basics = getBasicsCC();
+	auto it = find(basics.begin(), basics.end(), cc);
+	if (it != basics.end()) 
+		return it - basics.begin();
+	else throw megaglest_runtime_error("Basics command have not class: " + intToStr(cc));
 }
 
 // =====================================================

--- a/source/glest_game/types/command_type.h
+++ b/source/glest_game/types/command_type.h
@@ -54,6 +54,12 @@ enum CommandClass {
 	ccNull
 };
 
+enum CommandRow {
+	crCores,
+	crBasics,
+	crMorphs,
+};
+
 enum Clicks {
 	cOne,
 	cTwo
@@ -68,11 +74,10 @@ enum Queueability {
 
 class CommandHelper {// TODO put magic numbers to settings
 public:
-	inline static int getCorePos() {	return 0;	} 
-	inline static int getBasicPos() {	return 4;	} 
-	inline static int getMorphPos() {	return 8;	} 
+	inline static int getRowPos(CommandRow cr) { return cr * 4; } 
 	static int getBasicPos(CommandClass cc);
 	inline static vector<CommandClass> getBasicsCC() { return { ccAttack, ccStop, ccMove, ccAttackStopped }; }
+	inline static vector<CommandClass> getCoresCC() { return { ccAttack, ccProduce, ccUpgrade, ccSwitchTeam, ccHarvest, ccRepair, ccBuild }; }
 	
 private:
 	CommandHelper(){ }

--- a/source/glest_game/types/unit_type.cpp
+++ b/source/glest_game/types/unit_type.cpp
@@ -1238,73 +1238,57 @@ void UnitType::computeFirstCtOfClass() {
 
 void UnitType::sortCommandTypes(CommandTypes cts){
 	try{
-		CommandTypes ctBuf(cts); 
-		
-		CommandTypes ctCores;
-		CommandTypes ctBasics = {NULL,NULL,NULL,NULL};
+		CommandTypes ctCores, ctBasics = {NULL,NULL,NULL,NULL}, ctMorphs, ctAttack;
 		vector<int>	 basicNulls = {0,1,2,3};
-		CommandTypes ctMorphs;
-		
-		CommandTypes ctAttack;
-		CommandTypes ctBuild;
 
 		//Morphs
-		for(int i = (int)ctBuf.size(); i --> 0; ) {
-			if(ctBuf[i]->getClass() == ccMorph) {
-				ctMorphs.insert(ctMorphs.begin(), ctBuf[i]);
-				ctBuf.erase(ctBuf.begin() + i);
+		for(int i = (int)cts.size(); i --> 0; ) {
+			if(cts[i]->getClass() == ccMorph) {
+				ctMorphs.insert(ctMorphs.begin(), cts[i]);
+				cts.erase(cts.begin() + i);
 			}
 		}
 
 		//Attacks
-		CommandTypeFilter(ctBuf, ctAttack, ccAttack);
+		CommandTypeFilter(cts, ctAttack, ccAttack);
 		if(ctAttack.size() > 0) {
-			ctBasics[0] = ctAttack[0];// first attack to basics
+			ctBasics[CommandHelper::getBasicPos(ccAttack)] = ctAttack[0];// first attack to basics
 			basicNulls.erase(basicNulls.begin());
-			ctAttack.erase(ctAttack.begin());// another to cores
-			ctCores.insert(ctCores.end(), ctAttack.begin(), ctAttack.end());
+			ctAttack.erase(ctAttack.begin());// another to cores, see below
 		}
-		auto basicsCC = CommandHelper::getBasicsCC();
-		// removing attack cuz we catch all attacks above
-		basicsCC.erase( basicsCC.begin() + CommandHelper::getBasicPos(ccAttack)); 
 		
 		//Basics
-		for(int i = (int)ctBuf.size(); i --> 0; ) {
-			for(auto &&cc : basicsCC ){
-				if(ctBuf[i]->getClass() == cc) {
+		for(int i = (int)cts.size(); i --> 0; ) {
+			for(auto &&cc : CommandHelper::getBasicsCC()){
+				if(cc == ccAttack) continue;// we catch all attacks above
+				if(cts[i]->getClass() == cc) {
 					auto ccPos = CommandHelper::getBasicPos(cc);
-					ctBasics[ccPos] = ctBuf[i];
-					ctBuf.erase(ctBuf.begin() + i);
+					ctBasics[ccPos] = cts[i];
+					cts.erase(cts.begin() + i);
 					basicNulls.erase(std::remove(basicNulls.begin(), basicNulls.end(), ccPos), basicNulls.end());
 				}
 			}
 		}
 		
 		//Cores
-		CommandTypeFilter(ctBuf, ctCores, ccProduce);
-		CommandTypeFilter(ctBuf, ctCores, ccUpgrade);
-		CommandTypeFilter(ctBuf, ctCores, ccSwitchTeam);
-		CommandTypeFilter(ctBuf, ctCores, ccHarvest);
-		CommandTypeFilter(ctBuf, ctCores, ccRepair);
-
-		//Build
-		CommandTypeFilter(ctBuf, ctBuild, ccBuild);// Build position always 4 in cores
-		int nullCount = 4 - ctCores.size() - ctBuild.size();
+		for(auto &&cc : CommandHelper::getCoresCC()){
+			if(cc == ccAttack) ctCores.insert(ctCores.end(), ctAttack.begin(), ctAttack.end());
+			else CommandTypeFilter(cts, ctCores, cc);
+		}
+		int nullCount = 4 - ctCores.size();
 		for(int i=0; i<nullCount; i++){
 			ctCores.push_back(NULL);
 		}
-		if(ctBuild.size() > 0) {
-			if(nullCount < 0) {//magic
-				int buildToBasics = -nullCount;// if we cant push all builds to cores
-				int until = (int)ctBuild.size() - buildToBasics;
-				for(int i = (int)ctBuild.size(); i --> until; ) {// we push it to basics
-					ctBasics[basicNulls[i - until]] = ctBuild[i];
-					ctBuild.erase(ctBuild.begin() + i);
-					basicNulls.erase(basicNulls.begin() + i - until);
-				}
+		
+		if(nullCount < 0) {//magic: if we cant push all commands to cores
+			CommandTypes ctToBasics(ctCores.end() + nullCount, ctCores.end());
+			ctCores.resize(4);
+			for(int i = (int)ctToBasics.size(); i --> 0; ) {// we push it to basics
+				ctBasics[basicNulls[i]] = ctToBasics[i];
+				basicNulls.erase(basicNulls.begin() + i);
 			}
-			ctCores.insert(ctCores.end(), ctBuild.begin(), ctBuild.end());
 		}
+
 		commandTypesSorted.insert(commandTypesSorted.end(), ctCores.begin(), ctCores.end());
 		commandTypesSorted.insert(commandTypesSorted.end(), ctBasics.begin(), ctBasics.end());
 		commandTypesSorted.insert(commandTypesSorted.end(), ctMorphs.begin(), ctMorphs.end());

--- a/source/glest_game/types/unit_type.cpp
+++ b/source/glest_game/types/unit_type.cpp
@@ -1237,10 +1237,12 @@ void UnitType::computeFirstCtOfClass() {
 }
 
 void UnitType::sortCommandTypes(CommandTypes cts){
+	try{
 		CommandTypes ctBuf(cts); 
 		
 		CommandTypes ctCores;
 		CommandTypes ctBasics = {NULL,NULL,NULL,NULL};
+		vector<int>	 basicNulls = {0,1,2,3};
 		CommandTypes ctMorphs;
 		
 		CommandTypes ctAttack;
@@ -1258,6 +1260,7 @@ void UnitType::sortCommandTypes(CommandTypes cts){
 		CommandTypeFilter(ctBuf, ctAttack, ccAttack);
 		if(ctAttack.size() > 0) {
 			ctBasics[0] = ctAttack[0];// first attack to basics
+			basicNulls.erase(basicNulls.begin());
 			ctAttack.erase(ctAttack.begin());// another to cores
 			ctCores.insert(ctCores.end(), ctAttack.begin(), ctAttack.end());
 		}
@@ -1272,11 +1275,12 @@ void UnitType::sortCommandTypes(CommandTypes cts){
 					auto ccPos = CommandHelper::getBasicPos(cc);
 					ctBasics[ccPos] = ctBuf[i];
 					ctBuf.erase(ctBuf.begin() + i);
+					basicNulls.erase(std::remove(basicNulls.begin(), basicNulls.end(), ccPos), basicNulls.end());
 				}
 			}
 		}
 		
-// 		//Cores
+		//Cores
 		CommandTypeFilter(ctBuf, ctCores, ccProduce);
 		CommandTypeFilter(ctBuf, ctCores, ccUpgrade);
 		CommandTypeFilter(ctBuf, ctCores, ccSwitchTeam);
@@ -1285,19 +1289,28 @@ void UnitType::sortCommandTypes(CommandTypes cts){
 
 		//Build
 		CommandTypeFilter(ctBuf, ctBuild, ccBuild);// Build position always 4 in cores
-		if(ctCores.size() == 4) {/*do nothing*/ }
-		else if(ctCores.size() < 4) {
-			int nullCount = 4 - ctCores.size();
-			for(int i=0; i<nullCount; i++){
-				ctCores.push_back(NULL);
+		int nullCount = 4 - ctCores.size() - ctBuild.size();
+		for(int i=0; i<nullCount; i++){
+			ctCores.push_back(NULL);
+		}
+		if(ctBuild.size() > 0) {
+			if(nullCount < 0) {//magic
+				int buildToBasics = -nullCount;// if we cant push all builds to cores
+				int until = (int)ctBuild.size() - buildToBasics;
+				for(int i = (int)ctBuild.size(); i --> until; ) {// we push it to basics
+					ctBasics[basicNulls[i - until]] = ctBuild[i];
+					ctBuild.erase(ctBuild.begin() + i);
+					basicNulls.erase(basicNulls.begin() + i - until);
+				}
 			}
-			if(ctBuild.size() > 0){
-				ctCores[3] = ctBuild[0];
-			}
+			ctCores.insert(ctCores.end(), ctBuild.begin(), ctBuild.end());
 		}
 		commandTypesSorted.insert(commandTypesSorted.end(), ctCores.begin(), ctCores.end());
 		commandTypesSorted.insert(commandTypesSorted.end(), ctBasics.begin(), ctBasics.end());
 		commandTypesSorted.insert(commandTypesSorted.end(), ctMorphs.begin(), ctMorphs.end());
+	} catch(exception &ex){
+		
+	}
 }
 
 void UnitType::CommandTypeFilter(CommandTypes &input, CommandTypes &output, CommandClass cc){


### PR DESCRIPTION
this PR looking for second build  button, and if he can't leave it in cores, push it to basics, especially for  magic worker