### PR TITLE
Fixes for non-target commands

### DIFF
--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -647,29 +647,6 @@ void Gui::mouseDownDisplayUnitSkills(int posDisplay) {
 				if(selection.isUniform()) {
 					const CommandType *ct = display.getCommandType(posDisplay);
 
-					// try to switch to next attack type
-					if(activeCommandClass == ccAttack && activeCommandType!=NULL) {
-
-						int maxI			= unit->getType()->getCommandTypeCount();
-						int cmdTypeId		= activeCommandType->getId();
-						int cmdTypeIdNext	= cmdTypeId+1;
-
-						while(cmdTypeIdNext != cmdTypeId) {
-							if(cmdTypeIdNext >= maxI) {
-								cmdTypeIdNext = 0;
-							}
-							const CommandType *ctype = display.getCommandType(cmdTypeIdNext);
-							if(ctype != NULL && ctype->getClass() == ccAttack) {
-								if(ctype != NULL && unit->getFaction()->reqsOk(ctype)) {
-									posDisplay=cmdTypeIdNext;
-									ct = display.getCommandType(posDisplay);
-									break;
-								}
-							}
-							cmdTypeIdNext++;
-						}
-					}
-
 					if(ct != NULL && unit->getFaction()->reqsOk(ct)) {
 						activeCommandType= ct;
 						activeCommandClass= activeCommandType->getClass();
@@ -681,9 +658,7 @@ void Gui::mouseDownDisplayUnitSkills(int posDisplay) {
 						return;
 					}
 				}
-
-				//non uniform selection
-				else {
+				else {//non uniform selection
 					activeCommandType= NULL;
 					activeCommandClass= display.getCommandClass(posDisplay);
 					if (activeCommandClass  == ccAttack) {

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -439,6 +439,14 @@ void Gui::hotKey(SDL_KeyboardEvent key) {
 	if(isKeyPressed(configKeys.getSDLKey("HotKeySelectStoreUnit"),key) == true) {
 		selectInterestingUnit(iutStore);
 	}
+	//else if(key == configKeys.getCharKey("HotKeySelectedUnitsAttack")) {
+	if(isKeyPressed(configKeys.getSDLKey("HotKeySelectedUnitsAttack"),key) == true) {
+		clickCommonCommand(ccAttack);
+	}
+	//else if(key == configKeys.getCharKey("HotKeySelectedUnitsStop")) {
+	if(isKeyPressed(configKeys.getSDLKey("HotKeySelectedUnitsStop"),key) == true) {
+		clickCommonCommand(ccStop);
+	}
 
 	for (int i=0; i<commandKeys; i++) {
 		string name = "CommandKey" + intToStr(i+1);
@@ -637,6 +645,20 @@ void Gui::selectInterestingUnit(InterestingUnitType iut) {
 			}
 		}
 	}
+}
+
+void Gui::clickCommonCommand(CommandClass commandClass) {
+	for(int index = 0; index < Display::downCellCount; ++index) {
+		const CommandType *ct = display.getCommandType(index);
+
+		if((ct != NULL && ct->getClass() == commandClass) ||
+				display.getCommandClass(index) == commandClass) {
+
+			mouseDownDisplayUnitSkills(index);
+			break;
+		}
+	}
+	computeDisplay();
 }
 
 void Gui::mouseDownDisplayUnitSkills(int posDisplay) {

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -479,6 +479,8 @@ void Gui::giveOneClickOrders(){
 	addOrdersResultToConsole(activeCommandClass, result);
 	activeCommandType= NULL;
 	activeCommandClass= ccStop;
+	selectingPos= false;
+	activePos= invalidPos;
 }
 
 void Gui::giveDefaultOrders(int x, int y) {

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -439,14 +439,6 @@ void Gui::hotKey(SDL_KeyboardEvent key) {
 	if(isKeyPressed(configKeys.getSDLKey("HotKeySelectStoreUnit"),key) == true) {
 		selectInterestingUnit(iutStore);
 	}
-	//else if(key == configKeys.getCharKey("HotKeySelectedUnitsAttack")) {
-	if(isKeyPressed(configKeys.getSDLKey("HotKeySelectedUnitsAttack"),key) == true) {
-		clickCommonCommand(ccAttack);
-	}
-	//else if(key == configKeys.getCharKey("HotKeySelectedUnitsStop")) {
-	if(isKeyPressed(configKeys.getSDLKey("HotKeySelectedUnitsStop"),key) == true) {
-		clickCommonCommand(ccStop);
-	}
 
 	for (int i=0; i<commandKeys; i++) {
 		string name = "CommandKey" + intToStr(i+1);
@@ -643,20 +635,6 @@ void Gui::selectInterestingUnit(InterestingUnitType iut) {
 			}
 		}
 	}
-}
-
-void Gui::clickCommonCommand(CommandClass commandClass) {
-	for(int index = 0; index < Display::downCellCount; ++index) {
-		const CommandType *ct = display.getCommandType(index);
-
-		if((ct != NULL && ct->getClass() == commandClass) ||
-				display.getCommandClass(index) == commandClass) {
-
-			mouseDownDisplayUnitSkills(index);
-			break;
-		}
-	}
-	computeDisplay();
 }
 
 void Gui::mouseDownDisplayUnitSkills(int posDisplay) {

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -673,9 +673,12 @@ void Gui::mouseDownDisplayUnitSkills(int posDisplay) {
 					if (activeCommandClass  == ccAttack) {
 						ct = selection.getUnitFromCC(ccAttack)->getType()->getFirstCtOfClass(activeCommandClass);
 					}
+
 					if(activeCommandType!=NULL && activeCommandType->getClass()==ccBuild){
 						assert(selection.isUniform());
 						selectingBuilding= true;
+						selectingPos= false;
+						activePos= invalidPos;
 					}
 					else if(ct->getClicks()==cOne){
 						invalidatePosObjWorld();

--- a/source/glest_game/gui/gui.h
+++ b/source/glest_game/gui/gui.h
@@ -217,7 +217,6 @@ private:
 	//hotkeys
 	void centerCameraOnSelection();
 	void selectInterestingUnit(InterestingUnitType iut);
-	void clickCommonCommand(CommandClass commandClass);
 
 	//misc
 	int computePosDisplay(int x, int y);

--- a/source/glest_game/gui/gui.h
+++ b/source/glest_game/gui/gui.h
@@ -217,6 +217,7 @@ private:
 	//hotkeys
 	void centerCameraOnSelection();
 	void selectInterestingUnit(InterestingUnitType iut);
+	void clickCommonCommand(CommandClass commandClass);
 
 	//misc
 	int computePosDisplay(int x, int y);


### PR DESCRIPTION
this PR fixed problems, described below

1.  Selecting build command, after selected target command, for example 'mine', can crash game
2.  Stop command not removed previous command from cursor
3.  For few characters was impossible to select any command after selected attack, for example 'mage' from magic, 'technician' from tech 